### PR TITLE
Retire the use of Unsafe in favor of HC's MEM accessor which also works on aligned memory platforms

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>com.gkatzioura.maven.cloud</groupId>
+        <artifactId>google-storage-wagon</artifactId>
+        <version>1.0</version>
+    </extension>
+</extensions>

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 The snowcast project is not sponsored or started by nor affiliated to Hazelcast, Inc. in any possible way. It is a spare-time project and Hazelcast, even though I'm employed by Hazelcast, does not offer any support to this project. There is also no commercial support, not at the current point in time. Apart from that I will give support in the best way possible.
 
 ## Table of Contents
+* [DffrntLab specifics](#dffrntlab-specifics)
 * [The Problem](#the-problem)
 * [Common Solutions](#common-solutions)
 * [So What's Now?](#so-whats-now)
@@ -29,6 +30,18 @@ The snowcast project is not sponsored or started by nor affiliated to Hazelcast,
 * [Migration and Split Brain](#migration-and-split-brain)
 * [Hazelcast Clients](#hazelcast-clients)
 * [Build Information](#build-information)
+
+### DffrntLab specifics
+
+It a version of Snowcast which is based on newer version of Hazelcast `3.9` with HTTP health checks.
+
+Integration of the Hazelcast `3.9` with Snowcast is implemented in [lukasherman/snowcast](https://github.com/lukasherman/snowcast).
+
+#### Deploy process
+
+- `gcloud config set project dffrntlab-prod`
+- `gcloud auth application-default login`
+- `mvn deploy`
 
 ### The Problem
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,12 +25,12 @@
 
   <distributionManagement>
     <snapshotRepository>
-      <id>earthtoday-snapshot</id>
-      <url>gs://earthtoday-packages/artifacts/earthtoday/snapshot</url>
+      <id>hearhear-snapshot</id>
+      <url>gs://hearhear-packages/artifacts/hearhear/snapshot</url>
     </snapshotRepository>
     <repository>
-      <id>earthtoday-release</id>
-      <url>gs://earthtoday-packages/artifacts/earthtoday/release</url>
+      <id>hearhear-release</id>
+      <url>gs://hearhear-packages/artifacts/hearhear/release</url>
     </repository>
   </distributionManagement>
 
@@ -322,15 +322,15 @@
 
   <repositories>
     <repository>
-      <id>earthtoday-snapshot</id>
-      <url>gs://earthtoday-packages/artifacts/earthtoday/snapshot</url>
+      <id>hearhear-snapshot</id>
+      <url>gs://hearhear-packages/artifacts/hearhear/snapshot</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>
     </repository>
     <repository>
-      <id>earthtoday-release</id>
-      <url>gs://earthtoday-packages/artifacts/earthtoday/release</url>
+      <id>hearhear-release</id>
+      <url>gs://hearhear-packages/artifacts/hearhear/release</url>
     </repository>
   </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.noctarius.snowcast</groupId>
   <artifactId>snowcast</artifactId>
-  <version>2.1.0-SNAPSHOT</version>
+  <version>3.0.0-EarthToday</version>
   <description>snowcast is an auto-configuration, distributed, scalable ID generator on top of Hazelcast</description>
   <inceptionYear>2014</inceptionYear>
   <url>http://github.com/noctarius/snowcast</url>
@@ -25,23 +25,14 @@
 
   <distributionManagement>
     <snapshotRepository>
-      <id>sonatype-nexus-snapshots</id>
-      <name>Sonatype Nexus Snapshots</name>
-      <url>http://oss.sonatype.org/content/repositories/snapshots</url>
+      <id>earthtoday-snapshot</id>
+      <url>gs://earthtoday-packages/artifacts/earthtoday/snapshot</url>
     </snapshotRepository>
     <repository>
-      <id>sonatype-nexus-staging</id>
-      <name>Nexus Release Repository</name>
-      <url>http://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+      <id>earthtoday-release</id>
+      <url>gs://earthtoday-packages/artifacts/earthtoday/release</url>
     </repository>
   </distributionManagement>
-
-  <scm>
-    <connection>scm:git:git://github.com/noctarius/snowcast.git</connection>
-    <developerConnection>scm:git:git@github.com:noctarius/snowcast.git</developerConnection>
-    <url>https://github.com/noctarius/snowcast/</url>
-    <tag>HEAD</tag>
-  </scm>
 
   <developers>
     <developer>
@@ -63,11 +54,6 @@
     <system>github</system>
     <url>https://github.com/noctarius/snowcast/issues</url>
   </issueManagement>
-
-  <ciManagement>
-    <system>Jenkins</system>
-    <url>https://noctarius.ci.cloudbees.com/job/snowcast</url>
-  </ciManagement>
 
   <properties>
     <hazelcast.version>3.9</hazelcast.version>
@@ -141,6 +127,7 @@
         <filtering>true</filtering>
       </resource>
     </resources>
+
     <plugins>
       <plugin>
         <groupId>org.apache.felix</groupId>
@@ -205,26 +192,27 @@
             </configuration>
           </execution>
         </executions>
-      </plugin>      <plugin>
-        <groupId>org.apache.rat</groupId>
-        <artifactId>apache-rat-plugin</artifactId>
-        <version>0.9</version>
-        <executions>
-          <execution>
-            <phase>verify</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <excludes>
-            <exclude>README.md</exclude>
-            <exclude>LICENSE</exclude>
-            <exclude>*.svg</exclude>
-          </excludes>
-        </configuration>
       </plugin>
+      <!--<plugin>-->
+        <!--<groupId>org.apache.rat</groupId>-->
+        <!--<artifactId>apache-rat-plugin</artifactId>-->
+        <!--<version>0.9</version>-->
+        <!--<executions>-->
+          <!--<execution>-->
+            <!--<phase>verify</phase>-->
+            <!--<goals>-->
+              <!--<goal>check</goal>-->
+            <!--</goals>-->
+          <!--</execution>-->
+        <!--</executions>-->
+        <!--<configuration>-->
+          <!--<excludes>-->
+            <!--<exclude>README.md</exclude>-->
+            <!--<exclude>LICENSE</exclude>-->
+            <!--<exclude>*.svg</exclude>-->
+          <!--</excludes>-->
+        <!--</configuration>-->
+      <!--</plugin>-->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
@@ -264,39 +252,26 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.jacoco</groupId>
-        <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.7.7.201606060606</version>
-        <executions>
-          <execution>
-            <id>jacoco-initialize</id>
-            <goals>
-              <goal>prepare-agent</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>jacoco-site</id>
-            <phase>package</phase>
-            <goals>
-              <goal>report</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-scm-publish-plugin</artifactId>
-        <version>1.1</version>
-        <configuration>
-          <checkoutDirectory>${project.build.directory}/scmpublish</checkoutDirectory>
-          <checkinComment>Publishing javadoc for ${project.artifactId}:${project.version}</checkinComment>
-          <content>${project.build.directory}/apidocs</content>
-          <skipDeletedFiles>true</skipDeletedFiles>
-          <pubScmUrl>scm:git:git@github.com:noctarius/snowcast.git</pubScmUrl>
-          <scmBranch>gh-pages</scmBranch>
-        </configuration>
-      </plugin>
+      <!--<plugin>-->
+        <!--<groupId>org.jacoco</groupId>-->
+        <!--<artifactId>jacoco-maven-plugin</artifactId>-->
+        <!--<version>0.7.7.201606060606</version>-->
+        <!--<executions>-->
+          <!--<execution>-->
+            <!--<id>jacoco-initialize</id>-->
+            <!--<goals>-->
+              <!--<goal>prepare-agent</goal>-->
+            <!--</goals>-->
+          <!--</execution>-->
+          <!--<execution>-->
+            <!--<id>jacoco-site</id>-->
+            <!--<phase>package</phase>-->
+            <!--<goals>-->
+              <!--<goal>report</goal>-->
+            <!--</goals>-->
+          <!--</execution>-->
+        <!--</executions>-->
+      <!--</plugin>-->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
@@ -310,7 +285,16 @@
         </dependencies>
       </plugin>
     </plugins>
+
+    <extensions>
+      <extension>
+        <groupId>com.gkatzioura.maven.cloud</groupId>
+        <artifactId>google-storage-wagon</artifactId>
+        <version>1.0</version>
+      </extension>
+    </extensions>
   </build>
+
   <reporting>
     <plugins>
       <plugin>
@@ -378,15 +362,15 @@
 
   <repositories>
     <repository>
-      <id>sonatype-nexus-public</id>
-      <name>SonaType public snapshots and releases repository</name>
-      <url>https://oss.sonatype.org/content/groups/public</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
+      <id>earthtoday-snapshot</id>
+      <url>gs://earthtoday-packages/artifacts/earthtoday/snapshot</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>
+    </repository>
+    <repository>
+      <id>earthtoday-release</id>
+      <url>gs://earthtoday-packages/artifacts/earthtoday/release</url>
     </repository>
   </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -193,26 +193,6 @@
           </execution>
         </executions>
       </plugin>
-      <!--<plugin>-->
-        <!--<groupId>org.apache.rat</groupId>-->
-        <!--<artifactId>apache-rat-plugin</artifactId>-->
-        <!--<version>0.9</version>-->
-        <!--<executions>-->
-          <!--<execution>-->
-            <!--<phase>verify</phase>-->
-            <!--<goals>-->
-              <!--<goal>check</goal>-->
-            <!--</goals>-->
-          <!--</execution>-->
-        <!--</executions>-->
-        <!--<configuration>-->
-          <!--<excludes>-->
-            <!--<exclude>README.md</exclude>-->
-            <!--<exclude>LICENSE</exclude>-->
-            <!--<exclude>*.svg</exclude>-->
-          <!--</excludes>-->
-        <!--</configuration>-->
-      <!--</plugin>-->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
@@ -252,26 +232,6 @@
           </execution>
         </executions>
       </plugin>
-      <!--<plugin>-->
-        <!--<groupId>org.jacoco</groupId>-->
-        <!--<artifactId>jacoco-maven-plugin</artifactId>-->
-        <!--<version>0.7.7.201606060606</version>-->
-        <!--<executions>-->
-          <!--<execution>-->
-            <!--<id>jacoco-initialize</id>-->
-            <!--<goals>-->
-              <!--<goal>prepare-agent</goal>-->
-            <!--</goals>-->
-          <!--</execution>-->
-          <!--<execution>-->
-            <!--<id>jacoco-site</id>-->
-            <!--<phase>package</phase>-->
-            <!--<goals>-->
-              <!--<goal>report</goal>-->
-            <!--</goals>-->
-          <!--</execution>-->
-        <!--</executions>-->
-      <!--</plugin>-->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,21 +16,21 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.noctarius.snowcast</groupId>
   <artifactId>snowcast</artifactId>
-  <version>3.0.0-EarthToday</version>
+  <version>3.0.1-DffrntLab</version>
   <description>snowcast is an auto-configuration, distributed, scalable ID generator on top of Hazelcast</description>
   <inceptionYear>2014</inceptionYear>
-  <url>http://github.com/noctarius/snowcast</url>
+  <url>http://github.com/dffrntmedia/snowcast</url>
   <packaging>bundle</packaging>
   <name>snowcast</name>
 
   <distributionManagement>
     <snapshotRepository>
-      <id>hearhear-snapshot</id>
-      <url>gs://hearhear-packages/artifacts/hearhear/snapshot</url>
+      <id>${company.name}-snapshot</id>
+      <url>gs://${company.name}-packages/artifacts/${company.name}/snapshot</url>
     </snapshotRepository>
     <repository>
-      <id>hearhear-release</id>
-      <url>gs://hearhear-packages/artifacts/hearhear/release</url>
+      <id>${company.name}-release</id>
+      <url>gs://${company.name}-packages/artifacts/${company.name}/release</url>
     </repository>
   </distributionManagement>
 
@@ -59,6 +59,7 @@
     <hazelcast.version>3.9</hazelcast.version>
     <timestamp>${maven.build.timestamp}</timestamp>
     <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
+    <company.name>dffrntlab</company.name>
   </properties>
 
   <dependencies>
@@ -342,15 +343,15 @@
 
   <repositories>
     <repository>
-      <id>hearhear-snapshot</id>
-      <url>gs://hearhear-packages/artifacts/hearhear/snapshot</url>
+      <id>${company.name}-snapshot</id>
+      <url>gs://${company.name}-packages/artifacts/${company.name}/snapshot</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>
     </repository>
     <repository>
-      <id>hearhear-release</id>
-      <url>gs://hearhear-packages/artifacts/hearhear/release</url>
+      <id>${company.name}-release</id>
+      <url>gs://${company.name}-packages/artifacts/${company.name}/release</url>
     </repository>
   </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,17 @@
   </properties>
 
   <dependencies>
+    <!--Don't remove jsr305 and javax.annotation-api-->
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>3.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.3.2</version>
+    </dependency>
     <dependency>
       <groupId>com.hazelcast</groupId>
       <artifactId>hazelcast</artifactId>
@@ -129,6 +140,15 @@
     </resources>
 
     <plugins>
+<!--      <plugin>-->
+<!--        <groupId>org.apache.maven.plugins</groupId>-->
+<!--        <artifactId>maven-compiler-plugin</artifactId>-->
+<!--        <version>3.8.1</version>-->
+<!--        <configuration>-->
+<!--          <source>1.8</source>-->
+<!--          <target>1.8</target>-->
+<!--        </configuration>-->
+<!--      </plugin>-->
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
@@ -193,45 +213,45 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>attach-sources</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9</version>
-        <executions>
-          <execution>
-            <id>attach-javadocs</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-            <configuration>
-              <show>public</show>
-              <sourceFileExcludes>
-                <exclude>com/noctarius/snowcast/impl/*/*.java</exclude>
-              </sourceFileExcludes>
-              <sourceFileIncludes>
-                <include>com/noctarius/snowcast/*.java</include>
-              </sourceFileIncludes>
-              <excludePackageNames>*.impl.*</excludePackageNames>
-              <detectJavaApiLink>true</detectJavaApiLink>
-              <links>
-                <link>http://docs.hazelcast.org/docs/3.8/javadoc/</link>
-              </links>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
+<!--      <plugin>-->
+<!--        <groupId>org.apache.maven.plugins</groupId>-->
+<!--        <artifactId>maven-source-plugin</artifactId>-->
+<!--        <executions>-->
+<!--          <execution>-->
+<!--            <id>attach-sources</id>-->
+<!--            <goals>-->
+<!--              <goal>jar</goal>-->
+<!--            </goals>-->
+<!--          </execution>-->
+<!--        </executions>-->
+<!--      </plugin>-->
+<!--      <plugin>-->
+<!--        <groupId>org.apache.maven.plugins</groupId>-->
+<!--        <artifactId>maven-javadoc-plugin</artifactId>-->
+<!--        <version>2.9</version>-->
+<!--        <executions>-->
+<!--          <execution>-->
+<!--            <id>attach-javadocs</id>-->
+<!--            <goals>-->
+<!--              <goal>jar</goal>-->
+<!--            </goals>-->
+<!--            <configuration>-->
+<!--              <show>public</show>-->
+<!--              <sourceFileExcludes>-->
+<!--                <exclude>com/noctarius/snowcast/impl/*/*.java</exclude>-->
+<!--              </sourceFileExcludes>-->
+<!--              <sourceFileIncludes>-->
+<!--                <include>com/noctarius/snowcast/*.java</include>-->
+<!--              </sourceFileIncludes>-->
+<!--              <excludePackageNames>*.impl.*</excludePackageNames>-->
+<!--              <detectJavaApiLink>true</detectJavaApiLink>-->
+<!--              <links>-->
+<!--                <link>http://docs.hazelcast.org/docs/3.8/javadoc/</link>-->
+<!--              </links>-->
+<!--            </configuration>-->
+<!--          </execution>-->
+<!--        </executions>-->
+<!--      </plugin>-->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
@@ -301,20 +321,20 @@
               <remoteTagging>false</remoteTagging>
             </configuration>
           </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.4</version>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
+<!--          <plugin>-->
+<!--            <groupId>org.apache.maven.plugins</groupId>-->
+<!--            <artifactId>maven-gpg-plugin</artifactId>-->
+<!--            <version>1.4</version>-->
+<!--            <executions>-->
+<!--              <execution>-->
+<!--                <id>sign-artifacts</id>-->
+<!--                <phase>verify</phase>-->
+<!--                <goals>-->
+<!--                  <goal>sign</goal>-->
+<!--                </goals>-->
+<!--              </execution>-->
+<!--            </executions>-->
+<!--          </plugin>-->
         </plugins>
       </build>
     </profile>

--- a/src/test/java/com/noctarius/snowcast/DffrntLabSnowcastUseCaseTest.java
+++ b/src/test/java/com/noctarius/snowcast/DffrntLabSnowcastUseCaseTest.java
@@ -2,15 +2,12 @@ package com.noctarius.snowcast;
 
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 
-public class EarthTodaySnowcastTest {
-
-    @Ignore
+public class DffrntLabSnowcastUseCaseTest {
     @Test
     public void snowcastSequencerLifecycleTest() throws InterruptedException {
         HazelcastInstance hazelcastInstance = Hazelcast.newHazelcastInstance();
@@ -23,11 +20,10 @@ public class EarthTodaySnowcastTest {
 
         SnowcastEpoch epoch = SnowcastEpoch.byInstant(calendar.toInstant());
 
-        SnowcastSequencer sequencer = snowcast.createSequencer("earthTodaySequencer", epoch);
+        SnowcastSequencer sequencer = snowcast.createSequencer("dffrntlLabSequencer", epoch);
 
         sequencer.next();
 
         snowcast.destroySequencer(sequencer);
-
     }
 }

--- a/src/test/java/com/noctarius/snowcast/EarthTodaySnowcastTest.java
+++ b/src/test/java/com/noctarius/snowcast/EarthTodaySnowcastTest.java
@@ -2,13 +2,16 @@ package com.noctarius.snowcast;
 
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import org.junit.Ignore;
+import org.junit.Test;
 
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 
 public class EarthTodaySnowcastTest {
 
-    @org.junit.Test
+    @Ignore
+    @Test
     public void snowcastSequencerLifecycleTest() throws InterruptedException {
         HazelcastInstance hazelcastInstance = Hazelcast.newHazelcastInstance();
 

--- a/src/test/java/com/noctarius/snowcast/EarthTodaySnowcastTest.java
+++ b/src/test/java/com/noctarius/snowcast/EarthTodaySnowcastTest.java
@@ -1,0 +1,30 @@
+package com.noctarius.snowcast;
+
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+
+public class EarthTodaySnowcastTest {
+
+    @org.junit.Test
+    public void snowcastSequencerLifecycleTest() throws InterruptedException {
+        HazelcastInstance hazelcastInstance = Hazelcast.newHazelcastInstance();
+
+        Snowcast snowcast = SnowcastSystem.snowcast(hazelcastInstance);
+
+        Calendar calendar = GregorianCalendar.getInstance();
+
+        calendar.set(2018, Calendar.JANUARY, 1, 0, 0, 0);
+
+        SnowcastEpoch epoch = SnowcastEpoch.byInstant(calendar.toInstant());
+
+        SnowcastSequencer sequencer = snowcast.createSequencer("earthTodaySequencer", epoch);
+
+        sequencer.next();
+
+        snowcast.destroySequencer(sequencer);
+
+    }
+}


### PR DESCRIPTION
When using a JDK built for aarch64 this plugin throws consistent errors around the use of Unsafe on a platform without unaligned memory access support. This PR follows the deprecation of UnsafeUtils and switches to the global memory accessor registry instead.